### PR TITLE
Rename the should_failed check to should_fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Monkeyble allow to check the states of a task
   - task: "my_task_name"
     should_be_skipped: false
     should_be_changed: true
-    should_failed: false
+    should_fail: false
 ```
 
 ### Monkey patching

--- a/docs/states.md
+++ b/docs/states.md
@@ -14,7 +14,7 @@ monkeyble_scenarios:
       - task: "debug task"
         should_be_changed: true
         should_be_skipped: false
-        should_failed: false
+        should_fail: false
 ```
 
 ## States
@@ -55,23 +55,23 @@ monkeyble_scenarios:
   should_be_skipped: true
 ```
 
-### should_failed
+### should_fail
 
 ```yaml
 # Task example
-- name: "should_failed"
+- name: "should_fail"
   fail:
     msg: "save Palpatine"
 ```
 
 ```yaml
 # Monkeyble config
-- task: "should_failed"
-  should_failed: true
+- task: "should_fail"
+  should_fail: true
 ```
 
 !!!warning
 
     The normal return code when a task fail in an Ansible is **1**.
-    When a task is declared as `should_failed` in a Monkeyble and actually fail then the return code 
+    When a task is declared as `should_fail` in a Monkeyble and actually fail then the return code
      is **O** instead to prevent a CI/CD from concidering the test as a failure.

--- a/plugins/callback/monkeyble_callback.py
+++ b/plugins/callback/monkeyble_callback.py
@@ -206,7 +206,7 @@ class CallbackModule(CallbackBase):
         self._display.debug("Monkeyble check_if_task_should_have_failed called")
 
         result = self._compare_boolean_to_config(task_name=self._last_task_name,
-                                                 config_flag_name="should_failed",
+                                                 config_flag_name="should_fail",
                                                  task_config=self._last_task_config,
                                                  actual_state=task_has_actually_failed)
         if result is not None and result:

--- a/tests/ansible_test/run_ansible_tests.sh
+++ b/tests/ansible_test/run_ansible_tests.sh
@@ -69,7 +69,7 @@ LIST_SCENARIO=(
   "should_be_changed_true"
   "should_be_skipped"
   "should_not_be_skipped"
-  "should_failed"
+  "should_fail"
   "should_not_failed"
 )
 PLAYBOOK_PATH="test_task_state/playbook.yml"

--- a/tests/ansible_test/test_task_state/playbook.yml
+++ b/tests/ansible_test/test_task_state/playbook.yml
@@ -25,7 +25,7 @@
       debug:
         msg: "learn the force"
 
-    - name: "should_failed"
+    - name: "should_fail"
       fail:
         msg: "save Palpatine"
       ignore_errors: true

--- a/tests/ansible_test/test_task_state/test_state_failed/vars.yml
+++ b/tests/ansible_test/test_task_state/test_state_failed/vars.yml
@@ -19,12 +19,12 @@ monkeyble_scenarios:
       - task: "should_not_be_skipped"
         should_be_skipped: true
 
-  should_failed:
+  should_fail:
     tasks_to_test:
-      - task: "should_failed"
-        should_failed: false
+      - task: "should_fail"
+        should_fail: false
 
   should_not_failed:
     tasks_to_test:
       - task: "should_not_failed"
-        should_failed: true
+        should_fail: true

--- a/tests/ansible_test/test_task_state/test_state_passed/vars.yml
+++ b/tests/ansible_test/test_task_state/test_state_passed/vars.yml
@@ -13,8 +13,8 @@ monkeyble_scenarios:
       - task: "should_not_be_skipped"
         should_be_skipped: false
 
-      - task: "should_failed"
-        should_failed: true
+      - task: "should_fail"
+        should_fail: true
 
       - task: "should_not_failed"
-        should_failed: false
+        should_fail: false

--- a/tests/local_play.py
+++ b/tests/local_play.py
@@ -68,7 +68,7 @@ def main():
                         "task": "test_name2 with test_name2",
                         # "should_be_changed": True,
                         # "should_be_skipped": False,
-                        # "should_failed": False,
+                        # "should_fail": False,
                         "test_input": "{{ test_input_config_1 }}",
                         # "mock": {"config": "{{ replace_debug_mock }}"}
                     }

--- a/tests/monkeyble_scenarios.yml
+++ b/tests/monkeyble_scenarios.yml
@@ -21,7 +21,7 @@ monkeyble_scenarios:
 #        role: "ddzdz"
 #        should_be_changed: true
 #        should_be_skipped: true
-#        should_failed: true
+#        should_fail: true
 #        extra_vars:
 #          my_var: "general Organa"
 #        mock:

--- a/tests/units/test_callback/test_state.py
+++ b/tests/units/test_callback/test_state.py
@@ -14,7 +14,7 @@ class TestMonkeybleCallbackState(BaseTestMonkeybleCallback):
     def test_check_if_task_should_have_failed_continue_on_error_errors(self, mock_exit_playbook):
         self.test_callback._last_task_config = {
             "task": "test_task",
-            "should_failed": True
+            "should_fail": True
         }
         self.test_callback._last_task_ignore_errors = True
         self.test_callback.check_if_task_should_have_failed(task_has_actually_failed=True)
@@ -24,7 +24,7 @@ class TestMonkeybleCallbackState(BaseTestMonkeybleCallback):
     def test_check_if_task_should_have_failed_exit_zero_when_not_ignoring_errors(self, mock_exit_playbook):
         self.test_callback._last_task_config = {
             "task": "test_task",
-            "should_failed": True
+            "should_fail": True
         }
         self.test_callback._last_task_ignore_errors = False
         with self.assertRaises(MonkeybleException):


### PR DESCRIPTION
This is a proposal to change the name of the `should_failed` check to `should_fail`, as described in #11.