### PR TITLE
fix: Fixes documentation for test_input 'assert_dict_equal'

### DIFF
--- a/docs/test_input.md
+++ b/docs/test_input.md
@@ -237,8 +237,8 @@ A test case method expect two arguments:
 - task: "test_dict_equal"
   test_input:
     - assert_dict_equal:
-      arg_name: headers
-      expected:
-        key1: value1
-        key2: value2
+        arg_name: headers
+        expected:
+          key1: value1
+          key2: value2
 ```


### PR DESCRIPTION
I've spotted what I think is an error in the `test_input` `assert_dict_equal` doc.

```yaml
- task: "test_dict_equal"
  test_input:
    - assert_dict_equal:
      arg_name: headers
      expected:
        key1: value1
        key2: value2
```

should be

```yaml
- task: "test_dict_equal"
  test_input:
    - assert_dict_equal:
        arg_name: headers
        expected:
          key1: value1
          key2: value2
```