### PR TITLE
Allow either yml or yaml extension for config

### DIFF
--- a/monkeyble/cli/const.py
+++ b/monkeyble/cli/const.py
@@ -1,6 +1,6 @@
 MONKEYBLE = "Monkeyble"
 TEST_PASSED = "PASSED"
 TEST_FAILED = "FAILED"
-MONKEYBLE_DEFAULT_CONFIG_PATH = "monkeyble.yml"
+MONKEYBLE_DEFAULT_CONFIG_PATH = "monkeyble.y*ml"
 MONKEYBLE_DEFAULT_ANSIBLE_CMD = "ansible-playbook"
 MONKEYBLE_CALLBACK_STARTED = "Starting Monkeyble callback"

--- a/monkeyble/cli/monkeyble_cli.py
+++ b/monkeyble/cli/monkeyble_cli.py
@@ -154,9 +154,10 @@ def load_monkeyble_config(arg_config_path):
 
     try:
         config_file_path = glob.glob(config_path)[0]
-    except IndexError as e:
+        assert os.path.isfile(config_file_path) and os.access(config_file_path, os.R_OK)
+    except (IndexError, AssertionError) as e:
         Utils.print_danger(f"Monkeyble - config not found: {config_path}")
-        sys.exit(1)
+        sys.exit(2)
 
     logger.debug(f"Try to open file {config_file_path}")
     with open(config_file_path, "r") as stream:

--- a/monkeyble/cli/monkeyble_cli.py
+++ b/monkeyble/cli/monkeyble_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import logging
 import os
 import pathlib
@@ -150,14 +151,21 @@ def load_monkeyble_config(arg_config_path):
     # load from cli args
     if arg_config_path is not None:
         config_path = arg_config_path
-    logger.debug(f"Try to open file {config_path}")
-    with open(config_path, "r") as stream:
+
+    try:
+        config_file_path = glob.glob(config_path)[0]
+    except IndexError as e:
+        Utils.print_danger(f"Monkeyble - config not found: {config_path}")
+        sys.exit(1)
+
+    logger.debug(f"Try to open file {config_file_path}")
+    with open(config_file_path, "r") as stream:
         try:
             monkeyble_config = yaml.full_load(stream)
         except yaml.YAMLError as exc:
             Utils.print_danger(exc)
             sys.exit(1)
-    Utils.print_info(f"Monkeyble - config path: {config_path}")
+    Utils.print_info(f"Monkeyble - config path: {config_file_path}")
     return monkeyble_config
 
 

--- a/tests/units/test_cli.py
+++ b/tests/units/test_cli.py
@@ -6,7 +6,8 @@ import unittest
 from unittest import mock
 from unittest.mock import patch, mock_open, call
 
-from monkeyble.cli.const import TEST_PASSED, TEST_FAILED, MONKEYBLE_DEFAULT_ANSIBLE_CMD, MONKEYBLE_CALLBACK_STARTED
+from monkeyble.cli.const import TEST_PASSED, TEST_FAILED, MONKEYBLE_DEFAULT_ANSIBLE_CMD, MONKEYBLE_CALLBACK_STARTED, MONKEYBLE_DEFAULT_CONFIG_PATH
+
 from monkeyble.cli.exceptions import MonkeybleCLIException
 
 from monkeyble.cli.models import MonkeybleResult, ScenarioResult
@@ -17,20 +18,36 @@ from monkeyble.cli.monkeyble_cli import load_monkeyble_config, do_exit, run_monk
 class TestMonkeybleModule(unittest.TestCase):
 
     def test_load_monkeyble_config_default_config(self):
-        with patch("builtins.open", mock_open(read_data="data")) as mock_open_file:
-            load_monkeyble_config(None)
+        with (
+            patch("builtins.open", mock_open(read_data="data")) as mock_open_file,
+            patch("glob.glob", return_value=["monkeyble.yml"]) as mock_glob,
+            patch("os.path.isfile", return_value=True),
+            patch("os.access", return_value=True),
+            ):
+                load_monkeyble_config(None)
         mock_open_file.assert_called_with("monkeyble.yml", 'r')
+        mock_glob.assert_called_with(MONKEYBLE_DEFAULT_CONFIG_PATH)
 
     @mock.patch.dict(os.environ, {"MONKEYBLE_CONFIG": "monkeyble_from_env.yml"})
     def test_load_monkeyble_config_from_env(self):
-        with patch("builtins.open", mock_open(read_data="data")) as mock_open_file:
+        with (patch("builtins.open", mock_open(read_data="data")) as mock_open_file,
+              patch("glob.glob", return_value=["monkeyble_from_env.yml"]) as mock_glob,
+              patch("os.path.isfile", return_value=True),
+              patch("os.access", return_value=True),
+              ):
             load_monkeyble_config(None)
         mock_open_file.assert_called_with("monkeyble_from_env.yml", 'r')
+        mock_glob.assert_called_with("monkeyble_from_env.yml")
 
     def test_load_monkeyble_config_from_args(self):
-        with patch("builtins.open", mock_open(read_data="data")) as mock_open_file:
+        with (patch("builtins.open", mock_open(read_data="data")) as mock_open_file,
+              patch("glob.glob", return_value=["/path/to/monkeyble.yml"]) as mock_glob,
+              patch("os.path.isfile", return_value=True),
+              patch("os.access", return_value=True),
+              ):
             load_monkeyble_config("/path/to/monkeyble.yml")
         mock_open_file.assert_called_with("/path/to/monkeyble.yml", 'r')
+        mock_glob.assert_called_with("/path/to/monkeyble.yml")
 
     # fix path when executed as standalone test
     @patch("monkeyble.cli.monkeyble_cli.MONKEYBLE_DEFAULT_CONFIG_PATH", "tests/units/test_config/monkeyble.yml")


### PR DESCRIPTION
First thing that tripped me up using Monkeyble was this. I think YAML recommends .yaml but supporting both would be great.