### PR TITLE
only raise exception if should_fail is explicitly configured

### DIFF
--- a/plugins/callback/monkeyble_callback.py
+++ b/plugins/callback/monkeyble_callback.py
@@ -235,9 +235,9 @@ class CallbackModule(CallbackBase):
             message = f"🐵 Monkeyble - Task '{self._last_task_name}' was expected to fail but succeeded"
             raise MonkeybleException(message=message,
                                      scenario_description=self.monkeyble_scenario_description)
-        # case 2: task has failed and was not expected to fail
-        if task_has_actually_failed and not should_fail:
-            message = f"🐵 Monkeyble - Task '{self._last_task_name}' fail  and was not expected"
+        # case 2: task has failed and was explicitly expected not to fail
+        if task_has_actually_failed and "should_fail" in self._last_task_config and not should_fail:
+            message = f"🐵 Monkeyble - Task '{self._last_task_name}' failed and was not expected to"
             raise MonkeybleException(message=message,
                                      scenario_description=self.monkeyble_scenario_description)
         # case 3: task has failed and was expected to fail

--- a/tests/units/test_callback/test_state.py
+++ b/tests/units/test_callback/test_state.py
@@ -66,3 +66,12 @@ class TestMonkeybleCallbackState(BaseTestMonkeybleCallback):
         }
         with self.assertRaises(MonkeybleException):
             self.test_callback.check_if_task_should_have_failed(task_has_actually_failed=True)
+
+    @patch('sys.exit')
+    def test_check_if_task_failed_without_should_fail_configured(self, mock_exit_playbook):
+        """When should_fail is not in config at all, a failing task should not raise"""
+        self.test_callback._last_task_config = {
+            "task": "test_task"
+        }
+        self.test_callback.check_if_task_should_have_failed(task_has_actually_failed=True)
+        mock_exit_playbook.assert_not_called()


### PR DESCRIPTION
Ensure that a task failure only raises a MonkeybleException if the "should_fail" configuration key is present. This prevents the callback from interfering with tasks where failure expectations have not been defined.