### PR TITLE
prevent filesystem metadata from overwriting mock results

### DIFF
--- a/plugins/modules/monkeyble_module.py
+++ b/plugins/modules/monkeyble_module.py
@@ -27,6 +27,12 @@ def run_module():
     if module.params['result_dict']:
         result.update(module.params['result_dict'])
 
+    # Prevent AnsibleModule._return_formatted() from calling add_path_info().
+    # That method checks if a file at 'dest' or 'path' exists on the local filesystem
+    # and overwrites uid, gid, owner, group, mode, size, state with real values.
+    # This silently corrupts mock results when the target file happens to exist.
+    module.add_path_info = lambda kwargs: kwargs
+
     module.exit_json(**result)
 
 

--- a/tests/ansible_test/run_ansible_tests.sh
+++ b/tests/ansible_test/run_ansible_tests.sh
@@ -105,3 +105,9 @@ eval $ANSIBLE_CMD \
 test_mock/playbook.yml \
 -e "@test_mock/vars.yml" \
 -e "monkeyble_scenario=validate_test_passed"
+
+echo "Monkeyble test mock with dest/path key not altered by filesystem..."
+eval $ANSIBLE_CMD \
+test_mock_path_info/playbook.yml \
+-e "@test_mock_path_info/vars.yml" \
+-e "monkeyble_scenario=validate_test_passed"

--- a/tests/ansible_test/test_mock_path_info/playbook.yml
+++ b/tests/ansible_test/test_mock_path_info/playbook.yml
@@ -1,0 +1,39 @@
+- name: "Test mock result_dict with dest key is not altered by filesystem"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: "Ensure dest file exists to trigger the bug"
+      ansible.builtin.copy:
+        dest: /tmp/monkeyble_test_path_info.txt
+        content: "file exists on disk"
+        mode: "0644"
+
+    - name: "mock_copy_task"
+      ansible.builtin.copy:
+        dest: /tmp/monkeyble_test_path_info.txt
+        content: "this will be mocked"
+        mode: "0400"
+      register: mock_copy_result
+
+    - debug:
+        var: mock_copy_result
+
+    - name: "Assert mock result is returned exactly as defined"
+      assert:
+        that:
+          - "mock_copy_result['dest'] == '/tmp/monkeyble_mock_dest.txt'"
+          - "mock_copy_result['owner'] == 'mockowner'"
+          - "mock_copy_result['group'] == 'mockgroup'"
+          - "mock_copy_result['uid'] == 9999"
+          - "mock_copy_result['gid'] == 9999"
+          - "mock_copy_result['mode'] == '0400'"
+          - "mock_copy_result['size'] == 42"
+          - "mock_copy_result['state'] == 'file'"
+          - "mock_copy_result['changed'] == false"
+
+    - name: "Cleanup"
+      ansible.builtin.file:
+        path: /tmp/monkeyble_test_path_info.txt
+        state: absent

--- a/tests/ansible_test/test_mock_path_info/vars.yml
+++ b/tests/ansible_test/test_mock_path_info/vars.yml
@@ -1,0 +1,19 @@
+monkeyble_scenarios:
+  validate_test_passed:
+    tasks_to_test:
+      - task: "mock_copy_task"
+        mock:
+          config:
+            monkeyble_module:
+              consider_changed: false
+              result_dict:
+                changed: false
+                dest: /tmp/monkeyble_mock_dest.txt
+                owner: mockowner
+                group: mockgroup
+                uid: 9999
+                gid: 9999
+                mode: "0400"
+                size: 42
+                state: file
+                checksum: abc123


### PR DESCRIPTION
AnsibleModule._return_formatted() automatically probes the local filesystem for metadata when 'dest' or 'path' keys are present in the return dictionary. This overrides the add_path_info method to ensure mock results are not corrupted by real file attributes when a file exists on the target path.


Fixes #26 